### PR TITLE
update: Added a basic Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+# start from centos -- we all know why
+FROM centos:centos7
+
+# install nodejs
+RUN yum install -y http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-2.noarch.rpm
+RUN yum install -y nodejs npm
+
+# let's install mongodb
+RUN yum -y update; yum clean all
+RUN yum -y install epel-release; yum clean all
+RUN yum -y install mongodb-server; yum clean all
+RUN mkdir -p /data/db
+
+# Let's have the mongodb available from the outside, shall we
+EXPOSE 27017
+CMD ["/usr/bin/mongod"]
+
+# Bundle app source
+COPY . ./
+# Install app dependencies
+RUN cd ./; npm install
+
+# let's use the PORT we've been using up to now
+EXPOSE  1337
+
+# and start the app
+CMD ["/usr/bin/node", "app.js"]


### PR DESCRIPTION
- Added a basic Dockerfile with nodejs and mongodb to start to use
  tournamenter in a way it deserves.

Signed-off-by: mr.Shu mr@shu.io

---

This is a very first and very basic version of a Dockerfile that will in the end power `tournamenter`.

To get this, first of all you need to install docker (http://docs.docker.com/installation/mac/). Then you need to pull my build by running

```
docker pull mrshu/tournamenter
```

It's going to install a LOT of data (like around 800MB) but afterwards you can run

```
sudo docker run -p 12345:1337 -a stdin -a stdout -i -t mrshu/tournamenter 
```

Which will start tournamenter, open port 12345 on your machine and route the "internal" tournamenter's port (1337) into it. That way, tournamenter should be now available at http://127.0.0.1:12345/ on your machine.

@ivanseidel Do let me know if there are any problems with this -- would like to get them figured out.
