### PR TITLE
Fixed so it is possible to use sails-disk db for local testing

### DIFF
--- a/api/models/Team.js
+++ b/api/models/Team.js
@@ -10,7 +10,7 @@ module.exports = {
 
 	attributes: {
 		id: {
-			type: 'string',
+			type: 'integer',
 			autoIncrement: true,
 		},
 		name: {


### PR DESCRIPTION
Changed datatype of id in Team.js model from string to integer, see issue #23 .